### PR TITLE
Add a Free Jaffa crash-landed scenario

### DIFF
--- a/Defs/BackstoryDefs/BackstoryDef.xml
+++ b/Defs/BackstoryDefs/BackstoryDef.xml
@@ -113,53 +113,10 @@
         <amount>6</amount>
       </li>
       <li>
-        <defName>Mining</defName>
-        <amount>-12</amount>
-      </li>
-      <li>
-        <defName>Cooking</defName>
-        <amount>0</amount>
-      </li>
-      <li>
-        <defName>Plants</defName>
-        <amount>-12</amount>
-      </li>
-      <li>
-        <defName>Animals</defName>
-        <amount>4</amount>
-      </li>
-      <li>
-        <defName>Crafting</defName>
-        <amount>4</amount>
-      </li>
-      <li>
-        <defName>Artistic</defName>
-        <amount>4</amount>
-      </li>
-      <li>
         <defName>Medicine</defName>
-        <amount>0</amount>
-      </li>
-      <li>
-        <defName>Social</defName>
-        <amount>4</amount>
-      </li>
-      <li>
-        <defName>Intellectual</defName>
-        <amount>0</amount>
+        <amount>2</amount>
       </li>
     </skillGains>
-    <forcedTraits>
-      <li>
-        <defName>Beauty</defName>
-        <degree>2</degree>
-        <chance>20</chance>
-      </li>
-      <li>
-        <defName>Greedy</defName>
-        <chance>0</chance>
-      </li>
-    </forcedTraits>
     <workDisables>
     </workDisables>
   </AlienRace.BackstoryDef>
@@ -180,11 +137,11 @@
     <skillGains>
       <li>
         <defName>Melee</defName>
-        <amount>-12</amount>
+        <amount>0</amount>
       </li>
       <li>
         <defName>Shooting</defName>
-        <amount>-12</amount>
+        <amount>0</amount>
       </li>
       <li>
         <defName>Mining</defName>
@@ -208,7 +165,7 @@
       </li>
       <li>
         <defName>Crafting</defName>
-        <amount>0</amount>
+        <amount>2</amount>
       </li>
       <li>
         <defName>Artistic</defName>
@@ -216,7 +173,7 @@
       </li>
       <li>
         <defName>Medicine</defName>
-        <amount>-12</amount>
+        <amount>0</amount>
       </li>
       <li>
         <defName>Social</defName>
@@ -224,19 +181,9 @@
       </li>
       <li>
         <defName>Intellectual</defName>
-        <amount>-12</amount>
+        <amount>-2</amount>
       </li>
     </skillGains>
-    <forcedTraits>
-      <li>
-        <defName>Ascetic</defName>
-        <chance>100</chance>
-      </li>
-      <li>
-        <defName>Jealous</defName>
-        <chance>0</chance>
-      </li>
-    </forcedTraits>
     <workDisables>
     </workDisables>
   </AlienRace.BackstoryDef>

--- a/Defs/FactionDefs/Faction_Free_Jaffa_Player.xml
+++ b/Defs/FactionDefs/Faction_Free_Jaffa_Player.xml
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Defs>
+
+  <FactionDef Abstract="True" Name="JaffaFactionBase">
+    <colorSpectrum>
+      <li>(0, 0.737, 0.847)</li>
+    </colorSpectrum>
+  </FactionDef>
+
+  <FactionDef Parent="JaffaFactionBase">
+    <defName>JaffaPlayerColony</defName>
+    <label>Free Jaffa Colony</label>
+    <description>Your own community.</description>
+    <isPlayer>true</isPlayer>
+    <basicMemberKind>Jaffa_Colonist</basicMemberKind>
+    <pawnsPlural>Jaffa</pawnsPlural>
+    <playerInitialSettlementNameMaker>NamerInitialSettlementColony</playerInitialSettlementNameMaker>
+    <factionNameMaker>NamerFactionOutlander</factionNameMaker>
+    <settlementNameMaker>NamerSettlementOutlander</settlementNameMaker>
+    <techLevel>Ultra</techLevel>
+    <backstoryCategories>
+      <li>JaffaBackstory</li>
+      <li>SlaveBackstory</li>
+      <li>Civil</li>
+    </backstoryCategories>
+    <homeIconPath>World/GoauldBaseIcon</homeIconPath>
+    <expandingIconTexture>World/GoauldBaseIcon</expandingIconTexture>
+    <startingResearchTags>
+      <li>ClassicStart</li>
+    </startingResearchTags>
+    <hairTags>
+      <li>Urban</li>
+      <li>Rural</li>
+      <li>Tribal</li>
+      <li>Punk</li>
+    </hairTags>
+    <apparelStuffFilter>
+      <thingDefs>
+        <li>Synthread</li>
+      </thingDefs>
+    </apparelStuffFilter>
+
+  </FactionDef>
+
+  <FactionDef Parent="JaffaFactionBase">
+    <defName>JaffaPlayerColonyTribal</defName>
+    <label>Free Jaffa Tribal</label>
+    <description>Jaffa Tribal Start.</description>
+    <isPlayer>true</isPlayer>
+    <basicMemberKind>Jaffa_Colonist</basicMemberKind>
+    <pawnsPlural>Jaffa</pawnsPlural>
+    <playerInitialSettlementNameMaker>NamerInitialSettlementColony</playerInitialSettlementNameMaker>
+    <factionNameMaker>NamerFactionTribal</factionNameMaker>
+    <settlementNameMaker>NamerSettlementTribal</settlementNameMaker>
+    <techLevel>Ultra</techLevel>
+    <backstoryCategories>
+      <li>JaffaBackstory</li>
+      <li>SlaveBackstory</li>
+      <li>Civil</li>
+    </backstoryCategories>
+    <homeIconPath>World/GoauldBaseIcon</homeIconPath>
+    <expandingIconTexture>World/GoauldBaseIcon</expandingIconTexture>
+    <startingResearchTags>
+      <li>TribalStart</li>
+    </startingResearchTags>
+    <hairTags>
+      <li>Urban</li>
+      <li>Rural</li>
+      <li>Tribal</li>
+      <li>Punk</li>
+    </hairTags>
+    <apparelStuffFilter>
+      <thingDefs>
+        <li>Synthread</li>
+      </thingDefs>
+    </apparelStuffFilter>
+    <colorSpectrum>
+      <li>(0, 0.437, 0.847)</li>
+    </colorSpectrum>
+  </FactionDef>
+
+</Defs>

--- a/Defs/PawnKindDefs_Humanlikes/PawnKinds_Goauld.xml
+++ b/Defs/PawnKindDefs_Humanlikes/PawnKinds_Goauld.xml
@@ -85,6 +85,7 @@
 
   <PawnKindDef ParentName="GoauldCivBase">
     <defName>Goauld_Leader</defName>
+    <race>Alien_Goauld</race>
     <label>Lord</label>
     <labelPlural>Lords</labelPlural>
     <factionLeader>true</factionLeader>

--- a/Defs/PawnKindDefs_Humanlikes/PawnKinds_Player_Jaffa.xml
+++ b/Defs/PawnKindDefs_Humanlikes/PawnKinds_Player_Jaffa.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Defs>
+
+  <PawnKindDef Abstract="True" Name="BaseJaffaPawnKind">
+    <race>Alien_Jaffa</race>
+    <combatPower>40</combatPower>
+    <baseRecruitDifficulty>0.60</baseRecruitDifficulty>
+    <isFighter>false</isFighter>
+    <apparelIgnoreSeasons>true</apparelIgnoreSeasons>
+    <forceNormalGearQuality>true</forceNormalGearQuality>
+  </PawnKindDef>
+
+  <PawnKindDef ParentName="BaseJaffaPawnKind">
+    <defName>Jaffa_Colonist</defName>
+    <label>Jaffa</label>
+    <defaultFactionType>JaffaPlayerColony</defaultFactionType>
+    <backstoryCategories>
+      <li>JaffaBackstory</li>
+      <li>SlaveBackstory</li>
+      <li>Civil</li>
+    </backstoryCategories>
+    <apparelTags>
+      <li>Spacer</li>
+      <li>IndustrialBasic</li>
+    </apparelTags>
+    <apparelMoney>
+      <min>1000</min>
+      <max>2400</max>
+    </apparelMoney>
+    <minGenerationAge>18</minGenerationAge>
+    <maxGenerationAge>100</maxGenerationAge>
+  </PawnKindDef>
+
+</Defs>

--- a/Defs/Scenarios/Free_Jaffa.xml
+++ b/Defs/Scenarios/Free_Jaffa.xml
@@ -1,0 +1,107 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Defs>
+
+  <ScenarioDef>
+    <defName>FreeJaffaScenariox</defName>
+    <label>Free Jaffa Settlement</label>
+    <description>You and a small group of fellow Jaffa have crash landed on a new planet. Beset on all sides by danger and enemies, your fight for survival is just beginning...</description>
+    <scenario>
+      <summary>A small group of Jaffa try to build a new colony. Similar to the base Rimworld experience.</summary>
+      <playerFaction>
+        <def>PlayerFaction</def>
+        <factionDef>JaffaPlayerColony</factionDef>
+      </playerFaction>
+      <parts>
+        <li Class="ScenPart_ConfigPage_ConfigureStartingPawns">
+          <def>ConfigPage_ConfigureStartingPawns</def>
+          <pawnCount>3</pawnCount>
+          <pawnChoiceCount>8</pawnChoiceCount>
+        </li>
+        <li Class="ScenPart_PlayerPawnsArriveMethod">
+          <def>PlayerPawnsArriveMethod</def>
+          <method>DropPods</method>
+        </li>
+        <li Class="ScenPart_GameStartDialog">
+          <def>GameStartDialog</def>
+          <text>There was no choice, your Ha'tak was attacked and destroyed. Now you are stranded on the nearest planet. Better make the most of it, and try to find a way off this rock... Or maybe this will be home after all.</text>
+          <closeSound>GameStartSting</closeSound>
+        </li>
+        <li Class="ScenPart_StartingThing_Defined">
+          <def>StartingThing_Defined</def>
+          <thingDef>Silver</thingDef>
+          <count>800</count>
+        </li>
+        <li Class="ScenPart_StartingThing_Defined">
+          <def>StartingThing_Defined</def>
+          <thingDef>MealSurvivalPack</thingDef>
+          <count>50</count>
+        </li>
+        <li Class="ScenPart_StartingThing_Defined">
+          <def>StartingThing_Defined</def>
+          <thingDef>MedicineIndustrial</thingDef>
+          <count>30</count>
+        </li>
+        <li Class="ScenPart_StartingThing_Defined">
+          <def>StartingThing_Defined</def>
+          <thingDef>Jaffa_Helmet</thingDef>
+          <count>1</count>
+        </li>
+        <li Class="ScenPart_StartingThing_Defined">
+          <def>StartingThing_Defined</def>
+          <thingDef>Jaffa_Armor</thingDef>
+          <count>2</count>
+        </li>
+        <li Class="ScenPart_StartingThing_Defined">
+          <def>StartingThing_Defined</def>
+          <thingDef>Gun_JaffaStaff_blue</thingDef>
+          <count>2</count>
+        </li>
+        <li Class="ScenPart_StartingThing_Defined">
+          <def>StartingThing_Defined</def>
+          <thingDef>MeleeWeapon_JaffaKnife</thingDef>
+          <count>1</count>
+        </li>
+        <li Class="ScenPart_StartingAnimal">
+          <def>StartingAnimal</def>
+          <count>1</count>
+          <bondToRandomPlayerPawnChance>1</bondToRandomPlayerPawnChance>
+        </li>
+        <li Class="ScenPart_ScatterThingsNearPlayerStart">
+          <def>ScatterThingsNearPlayerStart</def>
+          <thingDef>WoodLog</thingDef>
+          <count>300</count>
+        </li>
+        <li Class="ScenPart_StartingThing_Defined">
+          <def>StartingThing_Defined</def>
+          <thingDef>Steel</thingDef>
+          <count>450</count>
+        </li>
+        <li Class="ScenPart_StartingThing_Defined">
+          <def>StartingThing_Defined</def>
+          <thingDef>ComponentIndustrial</thingDef>
+          <count>30</count>
+        </li>
+        <li Class="ScenPart_StartingResearch">
+          <def>StartingResearch</def>
+          <project>Pemmican</project>
+        </li>
+        <li Class="ScenPart_StartingResearch">
+          <def>StartingResearch</def>
+          <project>LongBlades</project>
+        </li>
+        <li Class="ScenPart_StartingResearch">
+          <def>StartingResearch</def>
+          <project>PlateArmor</project>
+        </li>
+        <li Class="ScenPart_StartingResearch">
+          <def>StartingResearch</def>
+          <project>Greatbow</project>
+        </li>
+        <li Class="ScenPart_StartingResearch">
+          <def>StartingResearch</def>
+          <project>Batteries</project>
+        </li>
+      </parts>
+    </scenario>
+  </ScenarioDef>
+</Defs>

--- a/Defs/ThingDefs_Races/Race_Jaffa.xml
+++ b/Defs/ThingDefs_Races/Race_Jaffa.xml
@@ -7,6 +7,9 @@
             <alienrefugeekinds>
                 <li>
                     <kindDefs>
+                        <li>Jaffa_Colonist</li>
+                        <li>Jaffa_Grenadier</li>
+                        <li>Jaffa_Melee</li>
                         <li>Jaffa_Warrior</li>
                     </kindDefs>
                     <chance>50.0</chance>
@@ -17,16 +20,14 @@
                     <pawnKindEntries>
                         <li>
                             <kindDefs>
-                                <li>Colonist</li>
-                                <li>Jaffa_Grenadier</li>
-                                <li>Jaffa_Melee</li>
-                                <li>Jaffa_Warrior</li>
+                                <li>Jaffa_Colonist</li>
                             </kindDefs>
                             <chance>10.0</chance>
                         </li>
                     </pawnKindEntries>
                     <factionDefs>
                         <li>GoauldPlayerColony</li>
+                        <li>JaffaPlayerColony</li>
                     </factionDefs>
                 </li>
             </startingColonists>
@@ -35,7 +36,7 @@
                     <pawnKindEntries>
                         <li>
                             <kindDefs>
-                                <li>Colonist</li>
+                                <li>Jaffa_Colonist</li>
                                 <li>Jaffa_Grenadier</li>
                                 <li>Jaffa_Melee</li>
                                 <li>Jaffa_Warrior</li>
@@ -45,6 +46,7 @@
                     </pawnKindEntries>
                     <factionDefs>
                         <li>GoauldPlayerColony</li>
+                        <li>JaffaPlayerColony</li>
                     </factionDefs>
                 </li>
             </alienwandererkinds>


### PR DESCRIPTION
Similar to the basic Rimworld scenario. The Jaffa backstories were tweaked to not appear so overpowered, and Jaffa can have regular backstories as well for more variety.

This is the scenario I'm using in my current playthrough.